### PR TITLE
Switch to MVI pattern

### DIFF
--- a/tournament-desktop/build.gradle.kts
+++ b/tournament-desktop/build.gradle.kts
@@ -1,5 +1,3 @@
-@file:Suppress("UNUSED_VARIABLE")
-
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 
 plugins {
@@ -28,7 +26,13 @@ kotlin {
 
                 implementation(project(":tournament-core"))
 
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.2")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-swing:1.7.2")
+
                 implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.5")
+
+                implementation("com.arkivanov.mvikotlin:mvikotlin-main:3.2.1")
+                implementation("com.arkivanov.mvikotlin:mvikotlin-extensions-coroutines:3.2.1")
             }
         }
         val jvmTest by getting

--- a/tournament-desktop/build.gradle.kts
+++ b/tournament-desktop/build.gradle.kts
@@ -46,6 +46,7 @@ compose.desktop {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
             packageName = "tournament-desktop"
             packageVersion = "1.0.0"
+            licenseFile = project.rootProject.file("LICENCE")
         }
     }
 }

--- a/tournament-desktop/build.gradle.kts
+++ b/tournament-desktop/build.gradle.kts
@@ -31,6 +31,7 @@ kotlin {
 
                 implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.5")
 
+                implementation("com.arkivanov.mvikotlin:mvikotlin:3.2.1")
                 implementation("com.arkivanov.mvikotlin:mvikotlin-main:3.2.1")
                 implementation("com.arkivanov.mvikotlin:mvikotlin-extensions-coroutines:3.2.1")
             }

--- a/tournament-desktop/src/jvmMain/kotlin/info/marozzo/tournament/desktop/Main.kt
+++ b/tournament-desktop/src/jvmMain/kotlin/info/marozzo/tournament/desktop/Main.kt
@@ -1,6 +1,7 @@
 package info.marozzo.tournament.desktop
 
-import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.unit.DpSize
@@ -8,33 +9,37 @@ import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowPlacement
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
+import com.arkivanov.mvikotlin.extensions.coroutines.states
+import com.arkivanov.mvikotlin.main.store.DefaultStoreFactory
 import info.marozzo.tournament.desktop.components.App
 import info.marozzo.tournament.desktop.components.CloseConfirmationDialog
 import info.marozzo.tournament.desktop.components.util.WithWidthClass
 import info.marozzo.tournament.desktop.theme.AppTheme
 
+fun main() {
+    val tournamentStore = TournamentStoreFactory(DefaultStoreFactory()).create()
+    application {
+        val state by tournamentStore.states.collectAsState(tournamentStore.state)
+        val windowState = rememberWindowState(
+            placement = WindowPlacement.Maximized, size = DpSize.Unspecified
+        )
+        val (isCloseRequested, setIsCloseRequested) = remember { mutableStateOf(false) }
+        Window(
+            title = "Tournament Planner",
+            state = windowState,
+            onCloseRequest = { setIsCloseRequested(true) },
+        ) {
+            AppTheme {
+                WithWidthClass {
 
-@OptIn(ExperimentalMaterialApi::class)
-fun main() = application {
-    val windowState = rememberWindowState(
-        placement = WindowPlacement.Maximized, size = DpSize.Unspecified
-    )
-    val (isCloseRequested, setIsCloseRequested) = remember { mutableStateOf(false) }
-    Window(
-        title = "Tournament Planner",
-        state = windowState,
-        onCloseRequest = { setIsCloseRequested(true) },
-    ) {
-        AppTheme {
-            WithWidthClass {
+                    App(state, tournamentStore::accept)
 
-                App()
-
-                CloseConfirmationDialog(
-                    isCloseRequested = isCloseRequested,
-                    onClose = { exitApplication() },
-                    onDismiss = { setIsCloseRequested(false) }
-                )
+                    CloseConfirmationDialog(
+                        isCloseRequested = isCloseRequested,
+                        onClose = { exitApplication() },
+                        onDismiss = { setIsCloseRequested(false) }
+                    )
+                }
             }
         }
     }

--- a/tournament-desktop/src/jvmMain/kotlin/info/marozzo/tournament/desktop/TournamentStore.kt
+++ b/tournament-desktop/src/jvmMain/kotlin/info/marozzo/tournament/desktop/TournamentStore.kt
@@ -2,8 +2,11 @@ package info.marozzo.tournament.desktop
 
 import com.arkivanov.mvikotlin.core.store.Store
 import info.marozzo.tournament.core.Match
+import info.marozzo.tournament.core.MatchResult
 import info.marozzo.tournament.core.Participant
+import info.marozzo.tournament.core.Round
 import info.marozzo.tournament.core.matchgenerators.MatchGenerator
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.PersistentMap
 
@@ -13,12 +16,13 @@ internal interface TournamentStore : Store<TournamentStore.Intent, TournamentSto
         data class AddParticipant(val name: String) : Intent
         data class RemoveParticipant(val participant: Participant): Intent
         data class ChangeMatchGenerator(val generator: MatchGenerator): Intent
-        data class EnterResult(val match: Match, val result: MatchResult): Intent
+        data class EnterResult(val result: MatchResult<*>): Intent
     }
 
     data class State(
         val participants: PersistentList<Participant>,
         val matchGenerator: MatchGenerator,
-        val matches: PersistentMap<Match, MatchResult?>
+        val rounds: ImmutableList<Round>,
+        val results: PersistentMap<Match, MatchResult<*>?>
     )
 }

--- a/tournament-desktop/src/jvmMain/kotlin/info/marozzo/tournament/desktop/TournamentStore.kt
+++ b/tournament-desktop/src/jvmMain/kotlin/info/marozzo/tournament/desktop/TournamentStore.kt
@@ -1,18 +1,24 @@
 package info.marozzo.tournament.desktop
 
 import com.arkivanov.mvikotlin.core.store.Store
+import info.marozzo.tournament.core.Match
 import info.marozzo.tournament.core.Participant
-import kotlinx.collections.immutable.ImmutableList
+import info.marozzo.tournament.core.matchgenerators.MatchGenerator
 import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.PersistentMap
 
 internal interface TournamentStore : Store<TournamentStore.Intent, TournamentStore.State, Nothing> {
 
     sealed interface Intent {
         data class AddParticipant(val name: String) : Intent
-
+        data class RemoveParticipant(val participant: Participant): Intent
+        data class ChangeMatchGenerator(val generator: MatchGenerator): Intent
+        data class EnterResult(val match: Match, val result: MatchResult): Intent
     }
 
     data class State(
-        val participants: PersistentList<Participant>
+        val participants: PersistentList<Participant>,
+        val matchGenerator: MatchGenerator,
+        val matches: PersistentMap<Match, MatchResult?>
     )
 }

--- a/tournament-desktop/src/jvmMain/kotlin/info/marozzo/tournament/desktop/TournamentStore.kt
+++ b/tournament-desktop/src/jvmMain/kotlin/info/marozzo/tournament/desktop/TournamentStore.kt
@@ -1,0 +1,18 @@
+package info.marozzo.tournament.desktop
+
+import com.arkivanov.mvikotlin.core.store.Store
+import info.marozzo.tournament.core.Participant
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.PersistentList
+
+internal interface TournamentStore : Store<TournamentStore.Intent, TournamentStore.State, Nothing> {
+
+    sealed interface Intent {
+        data class AddParticipant(val name: String) : Intent
+
+    }
+
+    data class State(
+        val participants: PersistentList<Participant>
+    )
+}

--- a/tournament-desktop/src/jvmMain/kotlin/info/marozzo/tournament/desktop/TournamentStoreFactory.kt
+++ b/tournament-desktop/src/jvmMain/kotlin/info/marozzo/tournament/desktop/TournamentStoreFactory.kt
@@ -3,11 +3,13 @@ package info.marozzo.tournament.desktop
 import com.arkivanov.mvikotlin.core.store.Reducer
 import com.arkivanov.mvikotlin.core.store.Store
 import com.arkivanov.mvikotlin.core.store.StoreFactory
-import com.arkivanov.mvikotlin.core.store.create
+import com.arkivanov.mvikotlin.extensions.coroutines.CoroutineExecutor
+import info.marozzo.tournament.core.Match
 import info.marozzo.tournament.core.Participant
+import info.marozzo.tournament.core.matchgenerators.MatchGenerator
 import info.marozzo.tournament.core.matchgenerators.RoundRobinTournamentMatchGenerator
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.persistentMapOf
+import kotlinx.collections.immutable.*
+import kotlinx.coroutines.launch
 
 internal class TournamentStoreFactory(private val storeFactory: StoreFactory) {
 
@@ -17,15 +19,63 @@ internal class TournamentStoreFactory(private val storeFactory: StoreFactory) {
             initialState = TournamentStore.State(
                 persistentListOf(), RoundRobinTournamentMatchGenerator(), persistentMapOf()
             ),
+            executorFactory = ::TournamentExecutor,
             reducer = TournamentReducer,
         ) {}
 
-    private object TournamentReducer : Reducer<TournamentStore.State, TournamentStore.Intent> {
-        override fun TournamentStore.State.reduce(msg: TournamentStore.Intent): TournamentStore.State = when (msg) {
-            is TournamentStore.Intent.AddParticipant -> copy(participants = participants.add(Participant(msg.name)))
-            is TournamentStore.Intent.RemoveParticipant -> copy(participants = participants.remove(msg.participant))
-            is TournamentStore.Intent.ChangeMatchGenerator -> copy(matchGenerator = msg.generator)
-            is TournamentStore.Intent.EnterResult -> copy(matches = matches.put(msg.match, msg.result))
+    private sealed interface Msg {
+        data class UpdateTournament(
+            val participants: PersistentList<Participant>,
+            val generator: MatchGenerator,
+            val matches: ImmutableList<Match>
+        ) : Msg
+
+        data class EnterResult(val match: Match, val result: MatchResult) : Msg
+    }
+
+    private object TournamentReducer : Reducer<TournamentStore.State, Msg> {
+        override fun TournamentStore.State.reduce(msg: Msg): TournamentStore.State = when (msg) {
+            is Msg.UpdateTournament -> copy(
+                participants = msg.participants,
+                matchGenerator = msg.generator,
+                matches = msg.matches.associateWith { null }.toPersistentMap()
+            )
+
+            is Msg.EnterResult -> copy(matches = matches.put(msg.match, msg.result))
         }
+    }
+
+    private class TournamentExecutor :
+        CoroutineExecutor<TournamentStore.Intent, Nothing, TournamentStore.State, Msg, Nothing>() {
+        override fun executeIntent(intent: TournamentStore.Intent, getState: () -> TournamentStore.State) {
+            val (participants, generator, _) = getState()
+
+            when (intent) {
+                is TournamentStore.Intent.AddParticipant -> regenerateMatches(
+                    participants.add(Participant(intent.name)),
+                    generator
+                )
+
+                is TournamentStore.Intent.RemoveParticipant -> regenerateMatches(
+                    participants.remove(intent.participant),
+                    generator
+                )
+
+                is TournamentStore.Intent.ChangeMatchGenerator -> regenerateMatches(participants, intent.generator)
+                is TournamentStore.Intent.EnterResult -> dispatch(Msg.EnterResult(intent.match, intent.result))
+            }
+        }
+
+        private fun regenerateMatches(participants: PersistentList<Participant>, matchGenerator: MatchGenerator) =
+            scope.launch {
+                val matches = matchGenerator.generate(participants)
+                dispatch(
+                    Msg.UpdateTournament(
+                        participants,
+                        matchGenerator,
+                        matches.flatMap { it.matches }.toImmutableList()
+                    )
+                )
+            }
     }
 }

--- a/tournament-desktop/src/jvmMain/kotlin/info/marozzo/tournament/desktop/TournamentStoreFactory.kt
+++ b/tournament-desktop/src/jvmMain/kotlin/info/marozzo/tournament/desktop/TournamentStoreFactory.kt
@@ -5,22 +5,27 @@ import com.arkivanov.mvikotlin.core.store.Store
 import com.arkivanov.mvikotlin.core.store.StoreFactory
 import com.arkivanov.mvikotlin.core.store.create
 import info.marozzo.tournament.core.Participant
+import info.marozzo.tournament.core.matchgenerators.RoundRobinTournamentMatchGenerator
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentMapOf
 
 internal class TournamentStoreFactory(private val storeFactory: StoreFactory) {
 
     fun create(): TournamentStore =
         object : TournamentStore, Store<TournamentStore.Intent, TournamentStore.State, Nothing> by storeFactory.create(
             name = "TournamentStore",
-            initialState = TournamentStore.State(persistentListOf()),
+            initialState = TournamentStore.State(
+                persistentListOf(), RoundRobinTournamentMatchGenerator(), persistentMapOf()
+            ),
             reducer = TournamentReducer,
         ) {}
 
     private object TournamentReducer : Reducer<TournamentStore.State, TournamentStore.Intent> {
         override fun TournamentStore.State.reduce(msg: TournamentStore.Intent): TournamentStore.State = when (msg) {
-            is TournamentStore.Intent.AddParticipant -> copy(
-                participants = participants.add(Participant(msg.name))
-            )
+            is TournamentStore.Intent.AddParticipant -> copy(participants = participants.add(Participant(msg.name)))
+            is TournamentStore.Intent.RemoveParticipant -> copy(participants = participants.remove(msg.participant))
+            is TournamentStore.Intent.ChangeMatchGenerator -> copy(matchGenerator = msg.generator)
+            is TournamentStore.Intent.EnterResult -> copy(matches = matches.put(msg.match, msg.result))
         }
     }
 }

--- a/tournament-desktop/src/jvmMain/kotlin/info/marozzo/tournament/desktop/TournamentStoreFactory.kt
+++ b/tournament-desktop/src/jvmMain/kotlin/info/marozzo/tournament/desktop/TournamentStoreFactory.kt
@@ -1,0 +1,26 @@
+package info.marozzo.tournament.desktop
+
+import com.arkivanov.mvikotlin.core.store.Reducer
+import com.arkivanov.mvikotlin.core.store.Store
+import com.arkivanov.mvikotlin.core.store.StoreFactory
+import com.arkivanov.mvikotlin.core.store.create
+import info.marozzo.tournament.core.Participant
+import kotlinx.collections.immutable.persistentListOf
+
+internal class TournamentStoreFactory(private val storeFactory: StoreFactory) {
+
+    fun create(): TournamentStore =
+        object : TournamentStore, Store<TournamentStore.Intent, TournamentStore.State, Nothing> by storeFactory.create(
+            name = "TournamentStore",
+            initialState = TournamentStore.State(persistentListOf()),
+            reducer = TournamentReducer,
+        ) {}
+
+    private object TournamentReducer : Reducer<TournamentStore.State, TournamentStore.Intent> {
+        override fun TournamentStore.State.reduce(msg: TournamentStore.Intent): TournamentStore.State = when (msg) {
+            is TournamentStore.Intent.AddParticipant -> copy(
+                participants = participants.add(Participant(msg.name))
+            )
+        }
+    }
+}


### PR DESCRIPTION
Switching to a MVI pattern because it simplifies state handling (single source of truth).
This is only for “application” state (the tournament data & settings) not explicit UI state (`isOpen`, etc.).